### PR TITLE
Bind `pswp` instance to data object of component, allowing access to photoSwipe instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ Use `options` for [Photoswipe options](http://photoswipe.com/documentation/optio
 <vue-picture-swipe :options="{shareEl: false}"></vue-picture-swipe>
 ```
 
+### PhotoSwipe instance
+
+You can access the PhotoSwipe instance via setting a ref, the instance object is exposed as `pswp`.
+
+```html
+<vue-picture-swipe ref="pictureSwipe"></vue-picture-swipe>
+```
+```js
+this.$refs.pictureSwipe.pswp
+```
+
+
 ## Why?
 
 I did not found any vue componant that uses thumbnail (smaller version of images) and is mobile-friendly (swipe)

--- a/src/VuePictureSwipe.vue
+++ b/src/VuePictureSwipe.vue
@@ -93,6 +93,7 @@
     },
     data() {
       return {
+        pswp: null,
         angle: 0
       };
     },
@@ -295,6 +296,7 @@
             }
           });
           gallery.init();
+          that.pswp = gallery;
         };
 
         // loop through all gallery elements and bind events


### PR DESCRIPTION
Can now access the `pswp` object instance to access the API, via setting a `ref`
```
    <vue-picture-swipe
      ref="pictureSwipe"
      :items="items"
      :options="options"
    ></vue-picture-swipe>
```

The `pswp` object is now bound to the data object of the component, so can now be accessed at : `this.$refs.pictureSwipe.pswp`