### PR TITLE
Avoid CSS rules "leaking" globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-picture-swipe",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Vue integration PhotoSwipe image plugin",
   "main": "src/main.js",
   "scripts": {

--- a/src/VuePictureSwipe.vue
+++ b/src/VuePictureSwipe.vue
@@ -3,7 +3,7 @@
     <div class="my-gallery" itemscope itemtype="http://schema.org/ImageGallery">
 
       <figure
-          v-show="index > 0 && !singleThumbnail"
+          v-show="index === 0 || !singleThumbnail"
           itemprop="associatedMedia"
           itemscope
           itemtype="http://schema.org/ImageObject"

--- a/src/VuePictureSwipe.vue
+++ b/src/VuePictureSwipe.vue
@@ -3,6 +3,7 @@
     <div class="my-gallery" itemscope itemtype="http://schema.org/ImageGallery">
 
       <figure
+          class="gallery-thumbnail"
           v-show="index === 0 || !singleThumbnail"
           itemprop="associatedMedia"
           itemscope
@@ -332,7 +333,7 @@
     }
   }
 </script>
-<style>
+<style scoped>
   .pswp__top-bar {
     text-align: right;
   }
@@ -349,7 +350,7 @@
   .pswp__button--rotate--right {
     background-position: -26px 10px;
   }
-  figure {
+  .gallery-thumbnail {
     display: inline;
     margin: 5px;
   }


### PR DESCRIPTION
I had some issues in my project with the CSS rules on `<figure>` being "leaked' globally.
Therefore I made a few minor changes to scope the styles, and also use a class for styling the thumbnails (instead of direcly putting it on `<figure>`). Did not change any actual styling.